### PR TITLE
Updating social share description and misspelling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Web site created using create-snowpack-app"
+      content="A free, open source, web based training tool designed to forever change the way we learn to type."
     />
     <title>dot i/o</title>
   </head>

--- a/src/pages/test/components/CustomTrainingSettingsBox.tsx
+++ b/src/pages/test/components/CustomTrainingSettingsBox.tsx
@@ -49,7 +49,7 @@ export function CustomTrainingSettingsBox(props: SettingsProps): JSX.Element {
     );
 
   const { parentProps: speedGoalProps, Popper: SpeelGoalPopover } = usePopover(
-    'How fast do you want to type each chord? This is measured in hundreths of a second, so a speed goal of 100 would equate to 1 second.',
+    'How fast do you want to type each chord? This is measured in hundredths of a second, so a speed goal of 100 would equate to 1 second.',
   );
 
   const { parentProps: recursionRateProps, Popper: RecursionRatePopover } =

--- a/src/pages/test/components/StatisticsTable.tsx
+++ b/src/pages/test/components/StatisticsTable.tsx
@@ -136,7 +136,7 @@ const Header = () => {
       <HeaderItemRow helpText="The name of the target chord or character you typed.">
         Chord
       </HeaderItemRow>
-      <HeaderItemRow helpText="The speed at which you typed the chord in hundreths of a second.">
+      <HeaderItemRow helpText="The speed at which you typed the chord in hundredths of a second.">
         Speed
       </HeaderItemRow>
       <HeaderItemRow helpText="The number of times you have made a mistake typing this chord.">

--- a/src/pages/training/components/CustomTrainingSettingsBox.tsx
+++ b/src/pages/training/components/CustomTrainingSettingsBox.tsx
@@ -50,7 +50,7 @@ export function CustomTrainingSettingsBox(props: SettingsProps): JSX.Element {
     );
 
   const { parentProps: speedGoalProps, Popper: SpeelGoalPopover } = usePopover(
-    'How fast do you want to type each chord? This is measured in hundreths of a second, so a speed goal of 100 would equate to 1 second.',
+    'How fast do you want to type each chord? This is measured in hundredths of a second, so a speed goal of 100 would equate to 1 second.',
   );
 
   const { parentProps: recursionRateProps, Popper: RecursionRatePopover } =

--- a/src/pages/training/components/StatisticsTable.tsx
+++ b/src/pages/training/components/StatisticsTable.tsx
@@ -137,7 +137,7 @@ const Header = () => {
       <HeaderItemRow helpText="The name of the target chord or character you typed.">
         Chord
       </HeaderItemRow>
-      <HeaderItemRow helpText="The speed at which you typed the chord in hundreths of a second.">
+      <HeaderItemRow helpText="The speed at which you typed the chord in hundredths of a second.">
         WPM
       </HeaderItemRow>
       <HeaderItemRow helpText="The number of times you have made a mistake typing this chord.">


### PR DESCRIPTION
Instead of this 
![image](https://user-images.githubusercontent.com/11359044/225902369-8614c7ed-d206-40c1-92f7-1db4cc8b90c3.png)

We should see instead a more favorable description

Also, fixed a misspelling