### PR TITLE
Add source map

### DIFF
--- a/snowpack.config.mjs
+++ b/snowpack.config.mjs
@@ -9,7 +9,7 @@ export default {
     '@snowpack/plugin-dotenv',
     [
       '@snowpack/plugin-typescript',
-      { 
+      {
         /* Yarn PnP workaround: see https://www.npmjs.com/package/@snowpack/plugin-typescript */
         ...(process.versions.pnp ? { tsc: 'yarn pnpify tsc' } : {}),
       },
@@ -33,6 +33,7 @@ export default {
     tailwindConfig: './tailwind.config.js',
   },
   buildOptions: {
+    sourcemap: true
     /* ... */
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "importsNotUsedAsValues": "error",
+    "sourceMap": true
   }
-  
+
 }


### PR DESCRIPTION
When I tried to fix some failed test suites and ran the test script, I found that the call stack showed the code locations from the built code as below.

```
<App> > should generate test data when beginning a training mode
      TypeError: Cannot read properties of null (reading 'statistics')
        at dist/store/trainingStore/actions.js:151:69
```

This is not developer-friendly and it should show the code locations from the source code instead.

After adding the settings according to [this comment](https://github.com/FredKSchott/snowpack/discussions/1200#discussioncomment-2730792), the output result would have the code locations from the source code as below.

```
<App> > should generate test data when beginning a training mode
      TypeError: Cannot read properties of null (reading 'statistics')
        at src/store/trainingStore/actions.ts:232:31
```

Also, the call stack in the developer tool of browsers would show the code locations after this. It's really helpful during development or debugging. 