### PR TITLE
fix: update CC1 device preview to align with quick reference guide

### DIFF
--- a/src/data/keyPositions.ts
+++ b/src/data/keyPositions.ts
@@ -1,6 +1,6 @@
 import type { KeyHighlightPosition } from '../models/keyHighlightPositions';
 
-//SectorGroup 1 includes: Alt, Shift, Ambi Throw, Num Shift
+//SectorGroup 1 includes: Alt, Shift, Mirror, Num Shift
 //SectorGroup 2 includes: U, , , ', Ctrl
 //SectorGroup 3 includes: O, I, ., Del
 //SectorGroup 4 includes: E, BS, Space, R
@@ -8,7 +8,7 @@ import type { KeyHighlightPosition } from '../models/keyHighlightPositions';
 //SectorGroup 6 includes: Click, W, Z, G
 //SectorGroup 7 includes:
 //SectorGroup 8 includes:
-//SectorGroup 9 includes: A, Enter, T, _
+//SectorGroup 9 includes: A, Enter, T, Space
 //SectorGroup 10 includes:
 //SectorGroup 11 includes: Tab, L, N, J
 //SectorGroup 12 includes: S, Y, ;, Ctrl

--- a/src/models/keyboardKeysMap.ts
+++ b/src/models/keyboardKeysMap.ts
@@ -12,10 +12,10 @@ export const NumShiftKey: KeyboardKey = {
   titleTransformOverride: 'rotate(135deg) translate(8px, 17px) scale(0.8)',
 };
 
-export const AmbiThrowKey: KeyboardKey = {
-  title: 'Ambi Throw',
+export const MirrorKey: KeyboardKey = {
+  title: 'Mirror',
   id: 3,
-  titleTransformOverride: 'rotate(-45deg) translate(-10px, -20px) scale(0.8)',
+  titleTransformOverride: 'rotate(-45deg) translate(-16px, -14px) scale(0.8)',
 };
 
 export const ShiftKey: KeyboardKey = {
@@ -39,7 +39,7 @@ export const KeyboardKeysMap: Record<number, KeyboardKey> = {
   [-1]: BlankKey,
   1: AltKey,
   2: NumShiftKey,
-  3: AmbiThrowKey,
+  3: MirrorKey,
   4: ShiftKey,
   5: CtrlKey,
   6: {
@@ -128,9 +128,8 @@ export const KeyboardKeysMap: Record<number, KeyboardKey> = {
     titleTransformOverride: 'translate(8px, 10px) rotate(135deg)',
   },
   26: {
-    title: 'Middle Click',
+    title: '/',
     id: 26,
-    titleTransformOverride: 'translate(-25px, -5px) rotate(135deg) scale(0.65)',
   },
   27: {
     title: 'Esc',
@@ -173,8 +172,9 @@ export const KeyboardKeysMap: Record<number, KeyboardKey> = {
     id: 35,
   },
   36: {
-    title: '_',
+    title: 'Space',
     id: 36,
+    titleTransformOverride: 'rotate(135deg) translate(13px, 10px) scale(0.8)',
   },
   // Mouse Control Keys
   37: {

--- a/src/models/sectorGroupSpecifier.ts
+++ b/src/models/sectorGroupSpecifier.ts
@@ -4,7 +4,7 @@ import {
   AltKey,
   NumShiftKey,
   ShiftKey,
-  AmbiThrowKey,
+  MirrorKey,
   CtrlKey,
 } from './keyboardKeysMap';
 import type { SectorGroupData, SectorGroupSpecifier } from './sectorGroup';
@@ -21,7 +21,7 @@ export const SectorGroupMap: Record<SectorGroupSpecifier, SectorGroupData> = {
     topKey: AltKey,
     leftKey: NumShiftKey,
     rightKey: ShiftKey,
-    bottomKey: AmbiThrowKey,
+    bottomKey: MirrorKey,
   },
   2: {
     topKey: CtrlKey,
@@ -93,7 +93,7 @@ export const SectorGroupMap: Record<SectorGroupSpecifier, SectorGroupData> = {
     topKey: AltKey,
     leftKey: ShiftKey,
     rightKey: NumShiftKey,
-    bottomKey: AmbiThrowKey,
+    bottomKey: MirrorKey,
   },
   14: {
     topKey: KeyboardKeysMap[49],

--- a/src/pages/manager/controls/maps.tsx
+++ b/src/pages/manager/controls/maps.tsx
@@ -3360,7 +3360,7 @@ const CHARACHORDER = [
   'h'.charCodeAt(0), //13, h
   'p'.charCodeAt(0), //14, p
   0x0000, //15, //'fed' is using this
-  0x0111, //16, ambi throw right
+  0x0111, //16, mirror right
   0x0113, //17, num-shift right
   0x0186, //18, alt right
   0x0185, //19, shift right
@@ -3405,7 +3405,7 @@ const CHARACHORDER = [
   'm'.charCodeAt(0), //58, m
   'c'.charCodeAt(0), //59, c
   0x0000, //60,
-  0x0110, //61, ambi throw left
+  0x0110, //61, mirror left
   0x0181, //62, shift left
   0x0182, //63, alt left
   0x0110, //64, num-shift left


### PR DESCRIPTION
Close #96 

1. change AmbiThrow key to Mirror key
2. change right index east key from _ to space
3. change left palm east key from middle click to /

<img width="403" alt="image" src="https://github.com/iq-eq-us/dot-io/assets/3810893/dac0c4ba-cf05-4c1b-88a0-c4d41fddc300">
