### PR TITLE
Filter serial devices to CharaChorder only

### DIFF
--- a/src/pages/manager/components/connect.tsx
+++ b/src/pages/manager/components/connect.tsx
@@ -8,7 +8,7 @@ import {
 import { getId } from '../components/getID';
 import { getCount } from '../../manager/components/countChords';
 
-const VENDOR_ID = 0x239a; // CharaChorder Vendor ID
+const CC_VENDOR_IDS = [0x239a, 0x303a]; // CharaChorder Vendor ID
 
 export async function startSerialConnection() {
   console.log('startSerialConnection()');
@@ -16,7 +16,7 @@ export async function startSerialConnection() {
     // Prompt user to select any serial port.
 
     MainControls.serialPort = await navigator?.serial?.requestPort({
-      filters: [{ usbVendorId: VENDOR_ID }],
+      filters: CC_VENDOR_IDS.map((id) => ({ usbVendorId: id })),
     });
     console.log('requestPort()');
     // Wait for the serial port to open.

--- a/src/pages/manager/components/connect.tsx
+++ b/src/pages/manager/components/connect.tsx
@@ -8,12 +8,16 @@ import {
 import { getId } from '../components/getID';
 import { getCount } from '../../manager/components/countChords';
 
+const VENDOR_ID = 0x239a; // CharaChorder Vendor ID
+
 export async function startSerialConnection() {
   console.log('startSerialConnection()');
   try {
     // Prompt user to select any serial port.
 
-    MainControls.serialPort = await navigator?.serial?.requestPort();
+    MainControls.serialPort = await navigator?.serial?.requestPort({
+      filters: [{ usbVendorId: VENDOR_ID }],
+    });
     console.log('requestPort()');
     // Wait for the serial port to open.
     await openSerialPort();


### PR DESCRIPTION
Basically the same as [Theaninova](https://github.com/Theaninova/dotio/blob/c0fb7373148ae2ab50625de7897f1506e98f5e88/src/lib/serial/device.ts#L28C34-L28C34)'s implementation.

Filters so that users are not given the option to select non-CC devices