### PR TITLE
Rename "populate table" to "Read chords from device"

### DIFF
--- a/src/pages/manager/components/download.tsx
+++ b/src/pages/manager/components/download.tsx
@@ -176,7 +176,7 @@ export function Download(): ReactElement {
         color="pink"
         onClick={() => getGet()}
       >
-        Populate Table
+        Read chords from device
       </button>
     </React.Fragment>
   );


### PR DESCRIPTION
Fixes: Enhancement: rename "populate table" to "Read chords from device" #80