### PR TITLE
fix: update CC1 device preview align with quick reference: _ to -

### DIFF
--- a/src/models/keyboardKeysMap.ts
+++ b/src/models/keyboardKeysMap.ts
@@ -123,9 +123,9 @@ export const KeyboardKeysMap: Record<number, KeyboardKey> = {
     id: 24,
   },
   25: {
-    title: '_',
+    title: '-',
     id: 25,
-    titleTransformOverride: 'translate(8px, 10px) rotate(135deg)',
+    titleTransformOverride: 'rotate(135deg) translate(5px, 5px) scale(2)',
   },
   26: {
     title: '/',


### PR DESCRIPTION
Change left palm north key from _ (underscore) to - (hyphen).
Center it on the preview key and scale it up 2x.
And reorder rotate and translate, to match the other titleTransformOverrides in the same file.

Before

![msedge_1EZFdFeOvU](https://github.com/iq-eq-us/dot-io/assets/13420573/1bfcce8c-474a-4064-af0d-696a780a670b)

After

![msedge_vrYMTCiU6K](https://github.com/iq-eq-us/dot-io/assets/13420573/55fc8502-cfc6-412a-9f0c-2caaa0a4eda5)
