### PR TITLE
fix: update CC1 device preview, horizontally align K with M and W with G

### DIFF
--- a/src/models/keyboardKeysMap.ts
+++ b/src/models/keyboardKeysMap.ts
@@ -100,6 +100,7 @@ export const KeyboardKeysMap: Record<number, KeyboardKey> = {
   19: {
     title: 'K',
     id: 19,
+    titleTransformOverride: 'rotate(-315deg) translate(0px, 4px)',
   },
   20: {
     title: 'C',
@@ -113,6 +114,7 @@ export const KeyboardKeysMap: Record<number, KeyboardKey> = {
   22: {
     title: 'W',
     id: 22,
+    titleTransformOverride: 'rotate(-315deg) translate(0px, 6px)',
   },
   23: {
     title: 'Z',


### PR DESCRIPTION
Before

![before](https://github.com/iq-eq-us/dot-io/assets/13420573/624c7249-aae4-4f5a-bfe7-d6b011c85d6e)

After

![after](https://github.com/iq-eq-us/dot-io/assets/13420573/d07e8dd2-242f-4059-8101-6f2ad4470295)

Animation

![godot4-colorpicker-draggable-areas-4](https://github.com/iq-eq-us/dot-io/assets/13420573/2556a298-ba41-411a-a93d-fac10d2c5bb2)
