### PR TITLE
Moved Add Chord Button

### DIFF
--- a/src/pages/manager/manager.tsx
+++ b/src/pages/manager/manager.tsx
@@ -24,6 +24,7 @@ import {
   ChordContainer,
   PageContainer,
   TopSectionContainer,
+  Column,
 } from '../manager/manager.styled';
 import { DeviceNavigationBar } from './components/DeviceNavigationBar';
 import ManagersDeviceOverlay from './components/ManagersDeviceOverlay';
@@ -76,15 +77,16 @@ const Manager = (): ReactElement => {
             <PressCommit />
           </Table>
           <PageContainer>
-            <ChordMapColumn />
-            <ChordContainer>
-              <div />
-              <div />
-              <AddHeaders />
-              <AddChordMap />
-            </ChordContainer>
+            <Column>
+              <ChordContainer>
+                <div />
+                <div />
+                <AddHeaders />
+                <AddChordMap />
+              </ChordContainer>
+              <ChordMapColumn />
+            </Column>
             <div className="h-1 w-6/12 mt-16 bg-[#3A5A42] rounded mb-10" />
-
             <Terminal />
           </PageContainer>
         </TopSectionContainer>


### PR DESCRIPTION
Moved the add Chord button above where the current imported and created cords are listed. Additionally organized them in a Column to ensure that the Button was placed above the Chords, and to make sure chords weren't too far off to the side.

New Look: 
![image](https://github.com/iq-eq-us/dot-io/assets/27928910/72ec37fa-43d9-46ef-b7af-2a76edec928f)

Old Look:
![image](https://github.com/iq-eq-us/dot-io/assets/27928910/dcc6a270-b6ed-40f0-9547-cc1baaa450a8)

Might be good in the future to be able to add new Cords from the bottom and the top once the list is big enough. Then be able to focus the screen on the new Chord that is created. So the user doesn't have to scroll.