### PR TITLE
Fixed Issue #161: Statistic Bar Lines

### DIFF
--- a/src/pages/test/components/ProgressBar.tsx
+++ b/src/pages/test/components/ProgressBar.tsx
@@ -372,7 +372,7 @@ export function ProgressBar(): ReactElement {
               <RightTerms>
                 {timeTakenToTypeEachWordInOrder?.length == 0 ? 0 : Accuracy}%
                 acc
-                <div>
+                <div className="text-[#38bdf8]">
                   {isNaN(averageOfLocalStats.toFixed(0))
                     ? '0'
                     : averageOfLocalStats.toFixed(0)}{' '}
@@ -384,7 +384,7 @@ export function ProgressBar(): ReactElement {
                 {wordsPracticedInOrder.length > 999
                   ? '999+Terms'
                   : wordsPracticedInOrder.length + ' Terms'}
-                <div>
+                <div className="text-[#ef4444]">
                   {timeTakenToTypeEachWordInOrder?.length == 0
                     ? 0
                     : timeTakenToTypeEachWordInOrder?.length < 11

--- a/src/pages/test/components/Range.tsx
+++ b/src/pages/test/components/Range.tsx
@@ -238,7 +238,8 @@ export const MultiRangeSlider = (
         <div
           className="thumb thumb-left absolute"
           style={{
-            backgroundColor: props.minValue > props.maxValue ? 'red' : 'blue',
+            backgroundColor:
+              props.minValue > props.maxValue ? '#ef4444' : '#38bdf8',
           }}
         ></div>
         <div
@@ -260,7 +261,8 @@ export const MultiRangeSlider = (
         <div
           className="thumb thumb-right absolute"
           style={{
-            backgroundColor: props.minValue > props.maxValue ? 'blue' : 'red',
+            backgroundColor:
+              props.minValue > props.maxValue ? '#38bdf8' : '#ef4444',
           }}
         ></div>
 


### PR DESCRIPTION

I fixed the Statistic Bar Lines and matched them to the corresponding word statistics. I also changed the blue to add more contrast with the grey of the background. 

New Look: 
<img width="750" alt="Screenshot 2023-09-11 at 6 44 43 PM" src="https://github.com/iq-eq-us/dot-io/assets/78891853/46b6d6d4-4a67-41dd-b522-762b1b5cb73f">

Old Look:
<img width="750" alt="Screenshot 2023-09-11 at 6 47 29 PM" src="https://github.com/iq-eq-us/dot-io/assets/78891853/4d8c35e8-040c-4647-a13a-725b134ccdf3">
