### PR TITLE
Fixed Issue #183: Rename Top Button from Connect to Manager

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -181,7 +181,7 @@ const Navbar = (): ReactElement => {
             <NavLinksImage open={false} src={Crown_Icon} alt="" />
           </NavMenuLink>
           <NavBtnLink href="#/manager" onClick={() => setTrainingLevel('')}>
-            Connect
+            <div className="text-white">Manager</div>
           </NavBtnLink>
           <button
             className="hover:bg-[#333] rounded"
@@ -322,20 +322,19 @@ const NavBtn = styled.button`
 
 const NavBtnLink = styled.a`
   border-radius: 50px;
-  background: rgb(34 197 94);
   white-space: nowrap;
   padding: 10px 22px;
   color: #222424;
   font-size: 16px;
   outline: none;
-  border: none;
+  border: 1px solid white;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   text-decoration: none;
 
   &:hover {
     color: #ffff;
-    background: #32cd32;
+    background: #01a049;
     transition: 0.3s ease out;
   }
 `;


### PR DESCRIPTION
Fixed Issue #183: Renamed Top Button from Connect to Manager

Old Look: 
<img width="208" alt="Screenshot 2023-09-12 at 12 59 51 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/1366e7e2-1bfb-4633-9f44-1aed16948469">


To follow the layout of the rest of the page, I made the background transparent with a white border to follow the color scheme the dashboard.

New Look:
<img width="208" alt="Screenshot 2023-09-12 at 1 40 59 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/97f0d8a0-d1bc-4ce2-a261-517e7ae2eaed">

Also upon hovering, the Manager button will highlight green, changed the contrast of the green to not be glaring to look at.

Hovering:
<img width="208" alt="Screenshot 2023-09-12 at 1 41 04 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/0f35332e-d0e3-459c-9b7f-c66d180ec609">
