### PR TITLE
Move add cord - 0 Index

### DIFF
--- a/src/pages/manager/manager.tsx
+++ b/src/pages/manager/manager.tsx
@@ -24,6 +24,7 @@ import {
   ChordContainer,
   PageContainer,
   TopSectionContainer,
+  Column,
 } from '../manager/manager.styled';
 import { DeviceNavigationBar } from './components/DeviceNavigationBar';
 import ManagersDeviceOverlay from './components/ManagersDeviceOverlay';
@@ -76,15 +77,16 @@ const Manager = (): ReactElement => {
             <PressCommit />
           </Table>
           <PageContainer>
-            <ChordMapColumn />
-            <ChordContainer>
-              <div />
-              <div />
-              <AddHeaders />
-              <AddChordMap />
-            </ChordContainer>
+            <Column>
+              <ChordContainer>
+                <div />
+                <div />
+                <AddHeaders />
+                <AddChordMap />
+              </ChordContainer>
+              <ChordMapColumn />
+            </Column>
             <div className="h-1 w-6/12 mt-16 bg-[#3A5A42] rounded mb-10" />
-
             <Terminal />
           </PageContainer>
         </TopSectionContainer>

--- a/src/store/managerStorageStore/actions.ts
+++ b/src/store/managerStorageStore/actions.ts
@@ -20,7 +20,7 @@ const managerStorageStoreActions: ManagerStoreActions = {
     state.downloadedChords.chords = payload;
   }),
   setSingleDownloadedChord: action((state, payload) => {
-    state.downloadedChords.chords.push(payload);
+    state.downloadedChords.chords.unshift(payload);
   }),
   deleteDownloadedChordsData: action((state, payload) => {
     const tempV = deleteChordInManager(state, payload);


### PR DESCRIPTION
Update of a previous pull request that updated the add Cord Button:

Cords are now properly added at the 0th index

![image](https://github.com/iq-eq-us/dot-io/assets/27928910/bc69672a-6c10-4dd2-9053-54af320fd69d)
Image reference of Cord being added before a previous Cord of hello was add.

Original Issue Link:
https://github.com/iq-eq-us/dot-io/issues/81