### PR TITLE
Fixed Issue #68: Tick Mark Legibility

### DIFF
--- a/src/pages/test/components/Range.tsx
+++ b/src/pages/test/components/Range.tsx
@@ -213,7 +213,7 @@ export const MultiRangeSlider = (
                 [...Array(10)].map((e, n) => (
                   <div key={n} className="ruler-sub-rule absolute"></div>
                 ))}
-              <div className="text-[6px] absolute font-bold m-auto text-center text-neutral-600 flex-col">
+              <div className="text-[10px] absolute font-bold -ml-2 text-center text-neutral-300 flex-col w-4">
                 {i * step}
               </div>
             </div>

--- a/src/pages/test/components/multirangeslider.css
+++ b/src/pages/test/components/multirangeslider.css
@@ -119,7 +119,7 @@
 }
 .multi-range-slider .ruler .ruler-rule {
 	border-left: solid 1px;
-	border-color: #525252;
+	border-color: white;
 
 	display: flex;
 	flex-grow: 1;
@@ -128,13 +128,13 @@
 }
 .multi-range-slider .ruler .ruler-rule:last-child {
 	border-right: solid 1px;
-	border-color: #525252;
+	border-color: white;
 
 }
 
 .multi-range-slider .ruler .ruler-sub-rule {
 	border-left: solid 1px;
-	border-color: #525252;
+	border-color: white;
 
 	/* border-bottom: solid 1px; */
 	display: flex;


### PR DESCRIPTION
Updated Tick Marks with different colors and improved text legibility. Fixed by both @rng190001 and @MsAbigailS. 

Old Look: 
<img width="750" alt="Screenshot 2023-09-18 at 2 29 58 PM" src="https://github.com/iq-eq-us/dot-io/assets/78891853/a61d67e0-5101-4453-95a2-f6c2e71bbeb3">

New Look: 
<img width="750" alt="Screenshot 2023-09-18 at 2 30 09 PM" src="https://github.com/iq-eq-us/dot-io/assets/78891853/3c0e6aa0-9d22-4d68-9ce2-2a2bc7ed629a">
