### PR TITLE
Updated Issue #181: Updated Manager Button Features

### DIFF
--- a/src/pages/manager/components/bootLoader.tsx
+++ b/src/pages/manager/components/bootLoader.tsx
@@ -1,5 +1,9 @@
 import React, { ReactElement } from 'react';
-import { sendCommandString, readGetNone } from '../controls/mainControls';
+import {
+  sendCommandString,
+  readGetNone,
+  MainControls,
+} from '../controls/mainControls';
 
 async function bootLoader() {
   //Sends the bootloader command to the charachorder via the serial API
@@ -9,6 +13,16 @@ async function bootLoader() {
   await readGetNone();
 }
 
+function successfulBootLoader() {
+  if (MainControls.serialPort != null) {
+    alert(
+      'Your CharaChorder will now appear as an external storage device on your computer’s file explorer or Finder app. It might be named one of the following: “Arduino”, “Seeduino”, “TinyUSB” or “CharaChorder X.',
+    );
+  } else {
+    alert('There is no serial connection to bootload at this moment.');
+  }
+}
+
 export function BootLoaderButton(): ReactElement {
   return (
     <React.Fragment>
@@ -16,6 +30,7 @@ export function BootLoaderButton(): ReactElement {
         className="sc-bYwzuL text-white rounded p-2 mb-4 inline-block ml-2 bg-[#333] hover:bg-[#3b3b3b] active:bg-[#222]"
         color="pink"
         onClick={() => bootLoader()}
+        onClickCapture={() => successfulBootLoader()}
       >
         BootLoader{' '}
       </button>

--- a/src/pages/manager/components/disconnect.tsx
+++ b/src/pages/manager/components/disconnect.tsx
@@ -33,6 +33,14 @@ export async function disconnectSerialConnection() {
   }
 }
 
+function successfulDisconnect() {
+  if (MainControls.serialPort != null) {
+    alert('Successfully disconnected from serial port!');
+  } else {
+    alert('There is no serial connection to disconnect from at this moment.');
+  }
+}
+
 export function DisconnectButton(): ReactElement {
   return (
     <React.Fragment>
@@ -44,6 +52,7 @@ export function DisconnectButton(): ReactElement {
         className="sc-bYwzuL text-white rounded p-2 mb-4 inline-block ml-2 bg-[#333] hover:bg-[#3b3b3b] active:bg-[#222] position-absolute"
         color="pink"
         onClick={() => disconnectSerialConnection()}
+        onClickCapture={() => successfulDisconnect()}
       >
         Disconnect{' '}
       </button>


### PR DESCRIPTION
Updated the Manager page:

Old look: 
<img width="396" alt="Screenshot 2023-09-18 at 7 09 30 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/ba4295f1-1fc3-4ff8-9c37-f2e00e5363e2">
New Look:
<img width="452" alt="Screenshot 2023-09-18 at 5 53 03 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/e34924d0-41b3-4e2f-9f86-0a38a7a44471">
<img width="460" alt="Screenshot 2023-09-18 at 5 52 44 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/fb9d4f72-ac2e-4b67-8b63-c81339d49508">

Added alerts to alert the user when clicking, if device is present then successful disconnect. If device isn't present, the error message as no serial device is connected.

Bootloader Features:
In addition, I noticed that if the user isn't familiar with the bootloader button, it might appear to be doing nothing, so added a feature where it guides the user to navigate to their file explorer to find where to update characorder files.
Old Look:
<img width="396" alt="Screenshot 2023-09-18 at 7 15 21 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/f9d8dcef-c9b0-46b8-ae9b-3206d0ff03e9">

New Look:
<img width="452" alt="Screenshot 2023-09-18 at 6 03 49 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/6b01310b-8eaf-470f-8779-2d968fe3209c">
- Informs user that device is not present to bootload.
<img width="452" alt="Screenshot 2023-09-18 at 6 02 43 PM" src="https://github.com/iq-eq-us/dot-io/assets/102173173/d38ae540-994e-4df6-be48-3b412b027f55">

- Guides users to bootloader drive.