### PR TITLE
Issues 199 and 70 fixed

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,6 +13,7 @@ import Crown_Icon from '../assets/Crown_icon.png';
 import StM_Icon from '../assets/StM.png';
 import tWPM_Icon from '../assets/tWPM.png';
 import LockIconWhite from '../../src/pages/test/components/LockIconWhite';
+import ConstructionIconWhite from '../../src/pages/test/components/ConstructionIconWhite';
 import { ScoresComponent } from './scoresComponent';
 import InfoIcon from '../../src/pages/test/components/InfoIcon';
 import type { TrainingLevels } from '../../src/models/trainingLevels';
@@ -144,17 +145,17 @@ const Navbar = (): ReactElement => {
           </NavMenuLink>
           <NavMenuLink aria-current="page">
             {trainingLevel == 'sWPM' ? <Circle /> : ''}
-            <LockIconStyle>
-              <LockIconWhite />
-            </LockIconStyle>
+            <ConstructionIconStyle>
+              <ConstructionIconWhite />
+            </ConstructionIconStyle>
             <NavLinksImage open={false} src={DumbellImage} alt="" />
           </NavMenuLink>
           <NavMenuLink aria-current="page">
             {trainingLevel == 'StM' ? <Circle /> : ''}
             <div className="text-white font-mono"></div>
-            <LockIconStyle>
-              <LockIconWhite />
-            </LockIconStyle>
+            <ConstructionIconStyle>
+              <ConstructionIconWhite />
+            </ConstructionIconStyle>
             <NavLinksImage
               open={false}
               src={StM_Icon}
@@ -163,15 +164,15 @@ const Navbar = (): ReactElement => {
             />
           </NavMenuLink>
           <NavMenuLink aria-current="page">
-            <LockIconStyle>
-              <LockIconWhite />
-            </LockIconStyle>
+            <ConstructionIconStyle>
+              <ConstructionIconWhite />
+            </ConstructionIconStyle>
             <NavLinksImage open={false} src={tWPM_Icon} alt="" />
           </NavMenuLink>
           <NavMenuLink aria-current="page">
-            <LockIconStyle>
-              <LockIconWhite />
-            </LockIconStyle>
+            <ConstructionIconStyle>
+              <ConstructionIconWhite />
+            </ConstructionIconStyle>
             <NavLinksImage open={false} src={CM_Icon} alt="" />
           </NavMenuLink>
         </NavMenu>
@@ -199,6 +200,10 @@ export default Navbar;
 
 const LockIconStyle = styled.div.attrs({
   className: `items-center justify-center pl-6`,
+})``;
+
+const ConstructionIconStyle = styled.div.attrs({
+  className: `border-2 border-transparent rounded-full items-center justify-center pl-6`,
 })``;
 
 const LogoLink = styled.a.attrs({

--- a/src/pages/test/components/ConstructionIconWhite.tsx
+++ b/src/pages/test/components/ConstructionIconWhite.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+function ConstructionIconWhite(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="grey"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="feather feather-lock"
+    >
+      {/* Box */}
+      <path d="M2,2 L2,12" />
+      <path d="M2,2 L22,2" />
+      <path d="M22,2 L22,12" />
+      <path d="M2,12 L22,12" />
+      {/* Legs */}
+      <path d="M5,14 L5,22" />
+      <path d="M19,14 L19,22" />
+      {/* Slashes */}
+      <path d="M10,2 L2,6" />
+      <path d="M18,2 L2,10" />
+      <path d="M22,4 L6,12" />
+      <path d="M22,8 L14,12" />
+    </svg>
+  );
+}
+
+export default ConstructionIconWhite;

--- a/src/pages/test/components/ProgressBar.tsx
+++ b/src/pages/test/components/ProgressBar.tsx
@@ -451,11 +451,11 @@ const ProgressBarOuter = styled.div.attrs({
 })``;
 
 const LeftTerms = styled.div.attrs({
-  className: `rotate-180 float-left text-xs text-neutral-400`,
+  className: `rotate-180 float-left text-xs text-neutral-400 w-20`,
 })``;
 
 const RightTerms = styled.div.attrs({
-  className: `rotate-180  text-xs text-neutral-400`,
+  className: `rotate-180  text-xs text-neutral-400 w-20`,
 })``;
 
 const WPMText = styled.div.attrs({


### PR DESCRIPTION
Fixed issues 199 and 70.

Issue 199: The text within the trapezoid summary will not stay within the trapezoid when users hit over 100 rWPM and 100 lWMP. The text also stays within the trapezoid when the screen resizes.

Before:
![image](https://github.com/iq-eq-us/dot-io/assets/62525212/c702ab98-0433-4d61-844d-7d5eec72784d)

After:
![image](https://github.com/iq-eq-us/dot-io/assets/62525212/11bc48e1-023d-4bcb-9f70-394ebc84fac7)

Issue 70: The lock icon has been changed to represent "under construction". 

Before: 
![image](https://github.com/iq-eq-us/dot-io/assets/62525212/ba5f873e-453e-4e0c-8098-174167d22274)

After: 
![image](https://github.com/iq-eq-us/dot-io/assets/62525212/25a75822-d5d8-4756-9748-1ef23e723ea7)

Fixed by @MsAbigailS @rng190001 @mackenziesalinas 