### PR TITLE
Minor style changes to device select dropdown

### DIFF
--- a/src/models/keyboardDropDownFolder/keyboardDropDown.tsx
+++ b/src/models/keyboardDropDownFolder/keyboardDropDown.tsx
@@ -176,7 +176,7 @@ const DropDownHeader = styled('div')`
 const DropDownListContainer = styled('div')``;
 
 const DropDownList = styled('ul')`
-  padding: 0.4em 0em 0em 0em;
+  padding: 0.8em 0;
   margin: 0;
   position: relative;
   background: white;
@@ -190,21 +190,19 @@ const DropDownList = styled('ul')`
   border-top-left-radius: 10px;
   border-bottom-right-radius: 10px;
   border-bottom-left-radius: 10px;
-  &:first-child {
-    padding-top: 0.8em;
-  }
 `;
 
 const ListItem = styled('li')`
   list-style: none;
-  margin-bottom: 0.8em;
   padding-left: 15px;
   width: 100%;
   padding-right: 62px;
+  text-align: left;
+  line-height: 2em;
+  white-space: nowrap;
   color: black;
   &:hover {
     background: grey;
-    color: black;
     font-size: 1rem;
   }
 `;


### PR DESCRIPTION
Some minor style changes to the device select dropdown, nothing too crazy. Hoping this addresses issue #5  since there's not a ton of information. Please let me know if I've accidentally departed from any global styles! Happy to make adjustments.

- Left justified list items (was centered)
- Padding between menu items is now controlled by the menu item line height, which allows the perceived padding to carry over to the hover effect on each line item
- Removed unnecessary re-declaration of `color: black` within the hover state since it's black in both cases
- Removed line wrap on menu items, which was causing an unnecessary scroll bar on the right side of the parent page, making the entire page shift slightly when the dropdown was opened
- Changed the one-off padding at the top to be both top and bottom for consistency